### PR TITLE
Setting KUBECONFIG for current step

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -91,10 +91,12 @@ function getKubectlPath() {
         return kubectlPath;
     });
 }
-function setContext() {
+function setContext(kubeconfigPath) {
     return __awaiter(this, void 0, void 0, function* () {
         let context = core.getInput('context');
         if (context) {
+            //To use kubectl commands, the environment variable KUBECONFIG needs to be set for this step 
+            process.env['KUBECONFIG'] = kubeconfigPath;
             const kubectlPath = yield getKubectlPath();
             let toolRunner = new toolrunner_1.ToolRunner(kubectlPath, ['config', 'use-context', context]);
             yield toolRunner.exec();
@@ -112,7 +114,7 @@ function run() {
         fs.writeFileSync(kubeconfigPath, kubeconfig);
         command_1.issueCommand('set-env', { name: 'KUBECONFIG' }, kubeconfigPath);
         console.log('KUBECONFIG environment variable is set');
-        yield setContext();
+        yield setContext(kubeconfigPath);
     });
 }
 run().catch(core.setFailed);

--- a/src/login.ts
+++ b/src/login.ts
@@ -89,9 +89,11 @@ async function getKubectlPath() {
     return kubectlPath;
 }
 
-async function setContext() {
+async function setContext(kubeconfigPath: string) {
     let context = core.getInput('context');
     if (context) {
+        //To use kubectl commands, the environment variable KUBECONFIG needs to be set for this step 
+        process.env['KUBECONFIG'] = kubeconfigPath;
         const kubectlPath = await getKubectlPath();
         let toolRunner = new ToolRunner(kubectlPath, ['config', 'use-context', context]);
         await toolRunner.exec();
@@ -108,7 +110,7 @@ async function run() {
     fs.writeFileSync(kubeconfigPath, kubeconfig);
     issueCommand('set-env', { name: 'KUBECONFIG' }, kubeconfigPath);
     console.log('KUBECONFIG environment variable is set');
-    await setContext();
+    await setContext(kubeconfigPath);
 }
 
 run().catch(core.setFailed);


### PR DESCRIPTION
The `set-env` command used in this action sets the environment variable (KUBECONFIG) which can be used in subsequent steps only. To be able to use kubectl commands in the same step (needed to set context), we need to set the environment variable for the current step as well.
Ref: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

Fixes: https://github.com/Azure/k8s-set-context/issues/10