### PR TITLE
Use @actions/core.exportVariable instead of set-env

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -9,8 +9,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.run = void 0;
 const core = require("@actions/core");
-const command_1 = require("@actions/core/lib/command");
 const path = require("path");
 const fs = require("fs");
 const io = require("@actions/io");
@@ -113,7 +113,7 @@ function run() {
         core.debug(`Writing kubeconfig contents to ${kubeconfigPath}`);
         fs.writeFileSync(kubeconfigPath, kubeconfig);
         fs.chmodSync(kubeconfigPath, '600');
-        command_1.issueCommand('set-env', { name: 'KUBECONFIG' }, kubeconfigPath);
+        core.exportVariable('KUBECONFIG', kubeconfigPath);
         console.log('KUBECONFIG environment variable is set');
         yield setContext(kubeconfigPath);
     });

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import { issueCommand } from '@actions/core/lib/command';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as io from '@actions/io';
@@ -109,7 +108,7 @@ export async function run() {
     core.debug(`Writing kubeconfig contents to ${kubeconfigPath}`);
     fs.writeFileSync(kubeconfigPath, kubeconfig);
     fs.chmodSync(kubeconfigPath, '600');
-    issueCommand('set-env', { name: 'KUBECONFIG' }, kubeconfigPath);
+    core.exportVariable('KUBECONFIG', kubeconfigPath);
     console.log('KUBECONFIG environment variable is set');
     await setContext(kubeconfigPath);
 }


### PR DESCRIPTION
`set-env` is now deprecated. `@actions/core` exposes `exportVariable` to be used instead.

https://github.com/actions/toolkit/tree/main/packages/core#exporting-variables

Will fix warnings like this
> The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/