### PR TITLE
separate action and execution by creating action.ts

### DIFF
--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,5 +1,5 @@
 import {getRequiredInputError} from '../tests/util'
-import {run} from './run'
+import {run} from './action'
 import fs from 'fs'
 import * as utils from './utils'
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,0 +1,33 @@
+import * as core from '@actions/core'
+import * as path from 'path'
+import * as fs from 'fs'
+import {Cluster, parseCluster} from './types/cluster'
+import {setContext, getKubeconfig} from './utils'
+
+/**
+ * Sets the Kubernetes context based on supplied action inputs
+ */
+export async function run() {
+   // get inputs
+   const clusterType: Cluster | undefined = parseCluster(
+      core.getInput('cluster-type', {
+         required: true
+      })
+   )
+   const runnerTempDirectory: string = process.env['RUNNER_TEMP']
+   const kubeconfigPath: string = path.join(
+      runnerTempDirectory,
+      `kubeconfig_${Date.now()}`
+   )
+
+   // get kubeconfig and update context
+   const kubeconfig: string = await getKubeconfig(clusterType)
+   const kubeconfigWithContext: string = setContext(kubeconfig)
+
+   // output kubeconfig
+   core.debug(`Writing kubeconfig contents to ${kubeconfigPath}`)
+   fs.writeFileSync(kubeconfigPath, kubeconfigWithContext)
+   fs.chmodSync(kubeconfigPath, '600')
+   core.debug('Setting KUBECONFIG environment variable')
+   core.exportVariable('KUBECONFIG', kubeconfigPath)
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,36 +1,5 @@
+import {run} from './action'
 import * as core from '@actions/core'
-import * as path from 'path'
-import * as fs from 'fs'
-import {Cluster, parseCluster} from './types/cluster'
-import {setContext, getKubeconfig} from './utils'
-
-/**
- * Sets the Kubernetes context based on supplied action inputs
- */
-export async function run() {
-   // get inputs
-   const clusterType: Cluster | undefined = parseCluster(
-      core.getInput('cluster-type', {
-         required: true
-      })
-   )
-   const runnerTempDirectory: string = process.env['RUNNER_TEMP']
-   const kubeconfigPath: string = path.join(
-      runnerTempDirectory,
-      `kubeconfig_${Date.now()}`
-   )
-
-   // get kubeconfig and update context
-   const kubeconfig: string = await getKubeconfig(clusterType)
-   const kubeconfigWithContext: string = setContext(kubeconfig)
-
-   // output kubeconfig
-   core.debug(`Writing kubeconfig contents to ${kubeconfigPath}`)
-   fs.writeFileSync(kubeconfigPath, kubeconfigWithContext)
-   fs.chmodSync(kubeconfigPath, '600')
-   core.debug('Setting KUBECONFIG environment variable')
-   core.exportVariable('KUBECONFIG', kubeconfigPath)
-}
 
 // Run the application
 run().catch(core.setFailed)


### PR DESCRIPTION
the action is being inadvertently executed when imported by `src/run.test.ts` since `src/run.ts` calls the `run` async function at the end.

to fix this I've moved the `run` function definition into a new file: `src/action.ts` and moved the corresponding test to `src/action.test.ts`, leaving only the call to execute the action in `src/run.ts` since this is the entry point for the action from GitHub's side.

this should unblock the following release: https://github.com/Azure/k8s-set-context/actions/runs/4018476655/jobs/6904143151#step:3:82

#68 
