### PR TITLE
Update to use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
 branding:
    color: 'blue'
 runs:
-   using: 'node16'
+   using: 'node20'
    main: 'lib/index.js'


### PR DESCRIPTION
Update action.yml to use Node 20--there are now deprecation warnings for Node 16 on action runs:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: azure/k8s-set-context@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

