### PR TITLE
Check format of the k8s secret input

### DIFF
--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -101,6 +101,15 @@ describe('Default kubeconfig', () => {
          )
       })
 
+      test('it responds with error if k8s-secret is not in yaml format', () => {
+         process.env['INPUT_K8S-URL'] = 'url'
+         process.env['INPUT_K8S-SECRET'] = 'simple string'
+
+         expect(() => getDefaultKubeconfig()).toThrow(
+            'k8s-secret is a string, when it should be YAML'
+         )
+      })
+
       test('it gets kubeconfig through service-account', () => {
          const k8sUrl = 'https://testing-dns-4za.hfp.earth.azmk8s.io:443'
          const token = 'ZXlKaGJHY2lPcUpTVXpJMU5pSX='

--- a/src/types/k8sSecret.ts
+++ b/src/types/k8sSecret.ts
@@ -14,6 +14,8 @@ export interface K8sSecret {
  */
 export function parseK8sSecret(secret: any): K8sSecret {
    if (!secret) throw Error('K8s secret yaml is invalid')
+   if (typeof secret === 'string')
+      throw Error('k8s-secret is a string, when it should be YAML')
    if (!secret.data) throw k8sSecretMissingFieldError('data')
    if (!secret.data.token) throw k8sSecretMissingFieldError('token')
    if (!secret.data['ca.crt']) throw k8sSecretMissingFieldError('ca.crt')


### PR DESCRIPTION
I think this change will make it easier to use this action. Because k8s secret may to some people sound confusing and instead of passing YAML they use k8s secret token (string).