### PR TITLE
#146 Adding optional kubeconfig encoding variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
    kubeconfig:
       description: 'Contents of kubeconfig file'
       required: false
+   kubeconfig-encoding:
+      description: 'Encoding of the kubeconfig input. Accepts "plaintext" (default) or "base64".'
+      required: false
+      default: 'plaintext'
    context:
       description: 'If your kubeconfig has multiple contexts, use this field to use a specific context, otherwise the default one would be chosen'
       required: false

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -1,14 +1,14 @@
-import * as fs from 'fs';
-import { getRequiredInputError } from '../../tests/util';
-import { createKubeconfig, getDefaultKubeconfig } from './default';
+import * as fs from 'fs'
+import {getRequiredInputError} from '../../tests/util'
+import {createKubeconfig, getDefaultKubeconfig} from './default'
 
 describe('Default kubeconfig', () => {
    test('it creates a kubeconfig with proper format', () => {
-      const certAuth = 'certAuth';
-      const token = 'token';
-      const clusterUrl = 'clusterUrl';
+      const certAuth = 'certAuth'
+      const token = 'token'
+      const clusterUrl = 'clusterUrl'
 
-      const kc = createKubeconfig(certAuth, token, clusterUrl);
+      const kc = createKubeconfig(certAuth, token, clusterUrl)
       const expected = JSON.stringify({
          apiVersion: 'v1',
          kind: 'Config',
@@ -18,106 +18,106 @@ describe('Default kubeconfig', () => {
                cluster: {
                   server: clusterUrl,
                   'certificate-authority-data': certAuth,
-                  'insecure-skip-tls-verify': false,
-               },
-            },
+                  'insecure-skip-tls-verify': false
+               }
+            }
          ],
-         users: [{ name: 'default-user', user: { token } }],
+         users: [{name: 'default-user', user: {token}}],
          contexts: [
             {
                name: 'loaded-context',
                context: {
                   cluster: 'default',
                   user: 'default-user',
-                  name: 'loaded-context',
-               },
-            },
+                  name: 'loaded-context'
+               }
+            }
          ],
          preferences: {},
-         'current-context': 'loaded-context',
-      });
-      expect(kc).toBe(expected);
-   });
+         'current-context': 'loaded-context'
+      })
+      expect(kc).toBe(expected)
+   })
 
    test('it throws error without method', () => {
       expect(() => getDefaultKubeconfig()).toThrow(
          getRequiredInputError('method')
-      );
-   });
+      )
+   })
 
    describe('default method', () => {
       beforeEach(() => {
-         process.env['INPUT_METHOD'] = 'default';
-      });
+         process.env['INPUT_METHOD'] = 'default'
+      })
 
       test('it throws error without kubeconfig', () => {
          expect(() => getDefaultKubeconfig()).toThrow(
             getRequiredInputError('kubeconfig')
-         );
-      });
+         )
+      })
 
       test('it gets default config through kubeconfig input', () => {
-         const kc = 'example kc';
-         process.env['INPUT_KUBECONFIG'] = kc;
+         const kc = 'example kc'
+         process.env['INPUT_KUBECONFIG'] = kc
 
-         expect(getDefaultKubeconfig()).toBe(kc);
-      });
+         expect(getDefaultKubeconfig()).toBe(kc)
+      })
 
       test('it gets default config through base64 kubeconfig input', () => {
-         const kc = 'example kc';
-         const base64Kc = Buffer.from(kc, 'utf-8').toString('base64');
-         process.env['INPUT_KUBECONFIG'] = base64Kc;
-         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64';
+         const kc = 'example kc'
+         const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
+         process.env['INPUT_KUBECONFIG'] = base64Kc
+         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
 
-         expect(getDefaultKubeconfig()).toBe(kc);
-      });
-   });
+         expect(getDefaultKubeconfig()).toBe(kc)
+      })
+   })
 
    test('it defaults to default method', () => {
-      process.env['INPUT_METHOD'] = 'unknown';
+      process.env['INPUT_METHOD'] = 'unknown'
 
-      const kc = 'example kc';
-      process.env['INPUT_KUBECONFIG'] = kc;
+      const kc = 'example kc'
+      process.env['INPUT_KUBECONFIG'] = kc
 
-      expect(getDefaultKubeconfig()).toBe(kc);
-   });
+      expect(getDefaultKubeconfig()).toBe(kc)
+   })
 
    test('it defaults to default method from service-principal', () => {
-      process.env['INPUT_METHOD'] = 'service-principal';
+      process.env['INPUT_METHOD'] = 'service-principal'
 
-      const kc = 'example kc';
-      process.env['INPUT_KUBECONFIG'] = kc;
+      const kc = 'example kc'
+      process.env['INPUT_KUBECONFIG'] = kc
 
-      expect(getDefaultKubeconfig()).toBe(kc);
-   });
+      expect(getDefaultKubeconfig()).toBe(kc)
+   })
 
    describe('service-account method', () => {
       beforeEach(() => {
-         process.env['INPUT_METHOD'] = 'service-account';
-      });
+         process.env['INPUT_METHOD'] = 'service-account'
+      })
 
       test('it throws error without cluster url', () => {
          expect(() => getDefaultKubeconfig()).toThrow(
             getRequiredInputError('k8s-url')
-         );
-      });
+         )
+      })
 
       test('it throws error without k8s secret', () => {
-         process.env['INPUT_K8S-URL'] = 'url';
+         process.env['INPUT_K8S-URL'] = 'url'
 
          expect(() => getDefaultKubeconfig()).toThrow(
             getRequiredInputError('k8s-secret')
-         );
-      });
+         )
+      })
 
       test('it gets kubeconfig through service-account', () => {
-         const k8sUrl = 'https://testing-dns-4za.hfp.earth.azmk8s.io:443';
-         const token = 'ZXlKaGJHY2lPcUpTVXpJMU5pSX=';
-         const cert = 'LS0tLS1CRUdJTiBDRWyUSUZJQ';
-         const k8sSecret = fs.readFileSync('tests/sample-secret.yml').toString();
+         const k8sUrl = 'https://testing-dns-4za.hfp.earth.azmk8s.io:443'
+         const token = 'ZXlKaGJHY2lPcUpTVXpJMU5pSX='
+         const cert = 'LS0tLS1CRUdJTiBDRWyUSUZJQ'
+         const k8sSecret = fs.readFileSync('tests/sample-secret.yml').toString()
 
-         process.env['INPUT_K8S-URL'] = k8sUrl;
-         process.env['INPUT_K8S-SECRET'] = k8sSecret;
+         process.env['INPUT_K8S-URL'] = k8sUrl
+         process.env['INPUT_K8S-SECRET'] = k8sSecret
 
          const expectedConfig = JSON.stringify({
             apiVersion: 'v1',
@@ -128,15 +128,15 @@ describe('Default kubeconfig', () => {
                   cluster: {
                      server: k8sUrl,
                      'certificate-authority-data': cert,
-                     'insecure-skip-tls-verify': false,
-                  },
-               },
+                     'insecure-skip-tls-verify': false
+                  }
+               }
             ],
             users: [
                {
                   name: 'default-user',
-                  user: { token: Buffer.from(token, 'base64').toString() },
-               },
+                  user: {token: Buffer.from(token, 'base64').toString()}
+               }
             ],
             contexts: [
                {
@@ -144,15 +144,15 @@ describe('Default kubeconfig', () => {
                   context: {
                      cluster: 'default',
                      user: 'default-user',
-                     name: 'loaded-context',
-                  },
-               },
+                     name: 'loaded-context'
+                  }
+               }
             ],
             preferences: {},
-            'current-context': 'loaded-context',
-         });
+            'current-context': 'loaded-context'
+         })
 
-         expect(getDefaultKubeconfig()).toBe(expectedConfig);
-      });
-   });
-});
+         expect(getDefaultKubeconfig()).toBe(expectedConfig)
+      })
+   })
+})

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -68,8 +68,6 @@ describe('Default kubeconfig', () => {
          const kc = 'example kc'
          const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
 
-         process.env['INPUT_KUBECONFIG'] = base64Kc
-
          jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
             if (name === 'method') return 'default'
             if (name === 'kubeconfig-encoding') return 'base64'

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -64,6 +64,17 @@ describe('Default kubeconfig', () => {
          expect(getDefaultKubeconfig()).toBe(kc)
       })
 
+      test('returns kubeconfig as plaintext when encoding is plaintext', () => {
+         const kc = 'example kc'
+         jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
+            if (name === 'method') return 'default'
+            if (name === 'kubeconfig-encoding') return 'plaintext'
+            if (name === 'kubeconfig') return kc
+            return ''
+         })
+         expect(getDefaultKubeconfig()).toBe(kc)
+      })
+
       test('it gets default config through base64 kubeconfig input', () => {
          const kc = 'example kc'
          const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
@@ -76,6 +87,22 @@ describe('Default kubeconfig', () => {
          })
 
          expect(getDefaultKubeconfig()).toBe(kc)
+      })
+
+      test('it throws error for unknown kubeconfig-encoding', () => {
+         const kc = 'example kc'
+         const unknownEncoding = 'foobar'
+
+         jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
+            if (name === 'method') return 'default'
+            if (name === 'kubeconfig-encoding') return unknownEncoding
+            if (name === 'kubeconfig') return kc
+            return ''
+         })
+
+         expect(() => getDefaultKubeconfig()).toThrow(
+            "Invalid kubeconfig-encoding: 'foobar'. Must be 'plaintext' or 'base64'."
+         )
       })
    })
 

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -1,14 +1,14 @@
-import * as fs from 'fs'
-import {getRequiredInputError} from '../../tests/util'
-import {createKubeconfig, getDefaultKubeconfig} from './default'
+import * as fs from 'fs';
+import { getRequiredInputError } from '../../tests/util';
+import { createKubeconfig, getDefaultKubeconfig } from './default';
 
 describe('Default kubeconfig', () => {
    test('it creates a kubeconfig with proper format', () => {
-      const certAuth = 'certAuth'
-      const token = 'token'
-      const clusterUrl = 'clusterUrl'
+      const certAuth = 'certAuth';
+      const token = 'token';
+      const clusterUrl = 'clusterUrl';
 
-      const kc = createKubeconfig(certAuth, token, clusterUrl)
+      const kc = createKubeconfig(certAuth, token, clusterUrl);
       const expected = JSON.stringify({
          apiVersion: 'v1',
          kind: 'Config',
@@ -18,106 +18,106 @@ describe('Default kubeconfig', () => {
                cluster: {
                   server: clusterUrl,
                   'certificate-authority-data': certAuth,
-                  'insecure-skip-tls-verify': false
-               }
-            }
+                  'insecure-skip-tls-verify': false,
+               },
+            },
          ],
-         users: [{name: 'default-user', user: {token}}],
+         users: [{ name: 'default-user', user: { token } }],
          contexts: [
             {
                name: 'loaded-context',
                context: {
                   cluster: 'default',
                   user: 'default-user',
-                  name: 'loaded-context'
-               }
-            }
+                  name: 'loaded-context',
+               },
+            },
          ],
          preferences: {},
-         'current-context': 'loaded-context'
-      })
-      expect(kc).toBe(expected)
-   })
+         'current-context': 'loaded-context',
+      });
+      expect(kc).toBe(expected);
+   });
 
    test('it throws error without method', () => {
       expect(() => getDefaultKubeconfig()).toThrow(
          getRequiredInputError('method')
-      )
-   })
+      );
+   });
 
    describe('default method', () => {
       beforeEach(() => {
-         process.env['INPUT_METHOD'] = 'default'
-      })
+         process.env['INPUT_METHOD'] = 'default';
+      });
 
       test('it throws error without kubeconfig', () => {
          expect(() => getDefaultKubeconfig()).toThrow(
             getRequiredInputError('kubeconfig')
-         )
-      })
+         );
+      });
 
       test('it gets default config through kubeconfig input', () => {
-         const kc = 'example kc'
-         process.env['INPUT_KUBECONFIG'] = kc
+         const kc = 'example kc';
+         process.env['INPUT_KUBECONFIG'] = kc;
 
-         expect(getDefaultKubeconfig()).toBe(kc)
-      })
+         expect(getDefaultKubeconfig()).toBe(kc);
+      });
 
       test('it gets default config through base64 kubeconfig input', () => {
-         const kc = 'example kc'
-         const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
-         process.env['INPUT_KUBECONFIG'] = base64Kc
-         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
+         const kc = 'example kc';
+         const base64Kc = Buffer.from(kc, 'utf-8').toString('base64');
+         process.env['INPUT_KUBECONFIG'] = base64Kc;
+         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64';
 
-         expect(getDefaultKubeconfig()).toBe(kc)
-      })
-   })
+         expect(getDefaultKubeconfig()).toBe(kc);
+      });
+   });
 
    test('it defaults to default method', () => {
-      process.env['INPUT_METHOD'] = 'unknown'
+      process.env['INPUT_METHOD'] = 'unknown';
 
-      const kc = 'example kc'
-      process.env['INPUT_KUBECONFIG'] = kc
+      const kc = 'example kc';
+      process.env['INPUT_KUBECONFIG'] = kc;
 
-      expect(getDefaultKubeconfig()).toBe(kc)
-   })
+      expect(getDefaultKubeconfig()).toBe(kc);
+   });
 
    test('it defaults to default method from service-principal', () => {
-      process.env['INPUT_METHOD'] = 'service-principal'
+      process.env['INPUT_METHOD'] = 'service-principal';
 
-      const kc = 'example kc'
-      process.env['INPUT_KUBECONFIG'] = kc
+      const kc = 'example kc';
+      process.env['INPUT_KUBECONFIG'] = kc;
 
-      expect(getDefaultKubeconfig()).toBe(kc)
-   })
+      expect(getDefaultKubeconfig()).toBe(kc);
+   });
 
    describe('service-account method', () => {
       beforeEach(() => {
-         process.env['INPUT_METHOD'] = 'service-account'
-      })
+         process.env['INPUT_METHOD'] = 'service-account';
+      });
 
       test('it throws error without cluster url', () => {
          expect(() => getDefaultKubeconfig()).toThrow(
             getRequiredInputError('k8s-url')
-         )
-      })
+         );
+      });
 
       test('it throws error without k8s secret', () => {
-         process.env['INPUT_K8S-URL'] = 'url'
+         process.env['INPUT_K8S-URL'] = 'url';
 
          expect(() => getDefaultKubeconfig()).toThrow(
             getRequiredInputError('k8s-secret')
-         )
-      })
+         );
+      });
 
       test('it gets kubeconfig through service-account', () => {
-         const k8sUrl = 'https://testing-dns-4za.hfp.earth.azmk8s.io:443'
-         const token = 'ZXlKaGJHY2lPcUpTVXpJMU5pSX='
-         const cert = 'LS0tLS1CRUdJTiBDRWyUSUZJQ'
-         const k8sSecret = fs.readFileSync('tests/sample-secret.yml').toString()
+         const k8sUrl = 'https://testing-dns-4za.hfp.earth.azmk8s.io:443';
+         const token = 'ZXlKaGJHY2lPcUpTVXpJMU5pSX=';
+         const cert = 'LS0tLS1CRUdJTiBDRWyUSUZJQ';
+         const k8sSecret = fs.readFileSync('tests/sample-secret.yml').toString();
 
-         process.env['INPUT_K8S-URL'] = k8sUrl
-         process.env['INPUT_K8S-SECRET'] = k8sSecret
+         process.env['INPUT_K8S-URL'] = k8sUrl;
+         process.env['INPUT_K8S-SECRET'] = k8sSecret;
 
          const expectedConfig = JSON.stringify({
             apiVersion: 'v1',
@@ -128,15 +128,15 @@ describe('Default kubeconfig', () => {
                   cluster: {
                      server: k8sUrl,
                      'certificate-authority-data': cert,
-                     'insecure-skip-tls-verify': false
-                  }
-               }
+                     'insecure-skip-tls-verify': false,
+                  },
+               },
             ],
             users: [
                {
                   name: 'default-user',
-                  user: {token: Buffer.from(token, 'base64').toString()}
-               }
+                  user: { token: Buffer.from(token, 'base64').toString() },
+               },
             ],
             contexts: [
                {
@@ -144,15 +144,15 @@ describe('Default kubeconfig', () => {
                   context: {
                      cluster: 'default',
                      user: 'default-user',
-                     name: 'loaded-context'
-                  }
-               }
+                     name: 'loaded-context',
+                  },
+               },
             ],
             preferences: {},
-            'current-context': 'loaded-context'
-         })
+            'current-context': 'loaded-context',
+         });
 
-         expect(getDefaultKubeconfig()).toBe(expectedConfig)
-      })      
-   })
-})
+         expect(getDefaultKubeconfig()).toBe(expectedConfig);
+      });
+   });
+});

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -145,5 +145,14 @@ describe('Default kubeconfig', () => {
 
          expect(getDefaultKubeconfig()).toBe(expectedConfig)
       })
+
+      test('it gets default config through base64 kubeconfig input', () => {
+         const kc = 'example kc'
+         const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
+         process.env['INPUT_KUBECONFIG'] = base64Kc
+         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
+
+         expect(getDefaultKubeconfig()).toBe(kc)
+      })
    })
 })

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -67,7 +67,7 @@ describe('Default kubeconfig', () => {
          const kc = 'example kc'
          const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
          process.env['INPUT_KUBECONFIG'] = base64Kc
-         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
+         process.env['INPUT_KUBECONFIG-ENCODING'] = 'base64'
 
          expect(getDefaultKubeconfig()).toBe(kc)
       })

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as core from '@actions/core'
 import {getRequiredInputError} from '../../tests/util'
 import {createKubeconfig, getDefaultKubeconfig} from './default'
 
@@ -66,8 +67,15 @@ describe('Default kubeconfig', () => {
       test('it gets default config through base64 kubeconfig input', () => {
          const kc = 'example kc'
          const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
+
          process.env['INPUT_KUBECONFIG'] = base64Kc
-         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
+
+         jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
+            if (name === 'method') return 'default'
+            if (name === 'kubeconfig-encoding') return 'base64'
+            if (name === 'kubeconfig') return base64Kc
+            return ''
+         })
 
          expect(getDefaultKubeconfig()).toBe(kc)
       })

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -67,7 +67,7 @@ describe('Default kubeconfig', () => {
          const kc = 'example kc'
          const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
          process.env['INPUT_KUBECONFIG'] = base64Kc
-         process.env['INPUT_KUBECONFIG-ENCODING'] = 'base64'
+         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
 
          expect(getDefaultKubeconfig()).toBe(kc)
       })

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -145,7 +145,6 @@ describe('Default kubeconfig', () => {
 
          expect(getDefaultKubeconfig()).toBe(expectedConfig)
       })
-
       test('it gets default config through base64 kubeconfig input', () => {
          const kc = 'example kc'
          const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')

--- a/src/kubeconfigs/default.test.ts
+++ b/src/kubeconfigs/default.test.ts
@@ -62,6 +62,15 @@ describe('Default kubeconfig', () => {
 
          expect(getDefaultKubeconfig()).toBe(kc)
       })
+
+      test('it gets default config through base64 kubeconfig input', () => {
+         const kc = 'example kc'
+         const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
+         process.env['INPUT_KUBECONFIG'] = base64Kc
+         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
+
+         expect(getDefaultKubeconfig()).toBe(kc)
+      })
    })
 
    test('it defaults to default method', () => {
@@ -144,14 +153,6 @@ describe('Default kubeconfig', () => {
          })
 
          expect(getDefaultKubeconfig()).toBe(expectedConfig)
-      })
-      test('it gets default config through base64 kubeconfig input', () => {
-         const kc = 'example kc'
-         const base64Kc = Buffer.from(kc, 'utf-8').toString('base64')
-         process.env['INPUT_KUBECONFIG'] = base64Kc
-         process.env['INPUT_KUBECONFIG_ENCODING'] = 'base64'
-
-         expect(getDefaultKubeconfig()).toBe(kc)
-      })
+      })      
    })
 })

--- a/src/kubeconfigs/default.ts
+++ b/src/kubeconfigs/default.ts
@@ -45,7 +45,7 @@ export function getDefaultKubeconfig(): string {
       default: {
          core.debug('Setting context using kubeconfig')
          let kubeconfig = core.getInput('kubeconfig', {required: true})
-         const encoding = core.getInput('kubeconfig-encoding') || 'plaintext'
+         const encoding = (core.getInput('kubeconfig-encoding') || 'plaintext').toLowerCase()
          if (encoding === 'base64') {
             kubeconfig = Buffer.from(kubeconfig, 'base64').toString('utf-8')
          }

--- a/src/kubeconfigs/default.ts
+++ b/src/kubeconfigs/default.ts
@@ -54,9 +54,14 @@ export function getDefaultKubeconfig(): string {
             core.getInput('kubeconfig-encoding')?.toLowerCase() ||
             ENCODING.PLAINTEXT
 
+         if (encoding !== ENCODING.BASE64 && encoding !== ENCODING.PLAINTEXT) {
+            throw new Error(
+               `Invalid kubeconfig-encoding: '${encoding}'. Must be 'plaintext' or 'base64'.`
+            )
+         }
          const kubeconfig =
             encoding === ENCODING.BASE64
-               ? Buffer.from(rawKubeconfig, ENCODING.BASE64).toString('utf-8')
+               ? Buffer.from(rawKubeconfig, 'base64').toString('utf-8')
                : rawKubeconfig
 
          return kubeconfig

--- a/src/kubeconfigs/default.ts
+++ b/src/kubeconfigs/default.ts
@@ -44,23 +44,23 @@ export function getDefaultKubeconfig(): string {
       }
       default: {
          core.debug('Setting context using kubeconfig')
-         const ENCODING = {
-            BASE64: 'base64',
-            PLAINTEXT: 'plaintext'
+         enum Encoding {
+            Base64 = 'base64',
+            Plaintext = 'plaintext'
          }
 
          const rawKubeconfig = core.getInput('kubeconfig', {required: true})
          const encoding =
             core.getInput('kubeconfig-encoding')?.toLowerCase() ||
-            ENCODING.PLAINTEXT
+            Encoding.Plaintext
 
-         if (encoding !== ENCODING.BASE64 && encoding !== ENCODING.PLAINTEXT) {
+         if (encoding !== Encoding.Base64 && encoding !== Encoding.Plaintext) {
             throw new Error(
                `Invalid kubeconfig-encoding: '${encoding}'. Must be 'plaintext' or 'base64'.`
             )
          }
          const kubeconfig =
-            encoding === ENCODING.BASE64
+            encoding === Encoding.Base64
                ? Buffer.from(rawKubeconfig, 'base64').toString('utf-8')
                : rawKubeconfig
 

--- a/src/kubeconfigs/default.ts
+++ b/src/kubeconfigs/default.ts
@@ -44,7 +44,12 @@ export function getDefaultKubeconfig(): string {
       }
       default: {
          core.debug('Setting context using kubeconfig')
-         return core.getInput('kubeconfig', {required: true})
+         let kubeconfig = core.getInput('kubeconfig', {required: true})
+         const encoding = core.getInput('kubeconfig-encoding') || 'plaintext'
+         if (encoding === 'base64') {
+            kubeconfig = Buffer.from(kubeconfig, 'base64').toString('utf-8')
+         }
+         return kubeconfig
       }
    }
 }

--- a/src/kubeconfigs/default.ts
+++ b/src/kubeconfigs/default.ts
@@ -44,13 +44,21 @@ export function getDefaultKubeconfig(): string {
       }
       default: {
          core.debug('Setting context using kubeconfig')
-         let kubeconfig = core.getInput('kubeconfig', {required: true})
-         const encoding = (
-            core.getInput('kubeconfig-encoding') || 'plaintext'
-         ).toLowerCase()
-         if (encoding === 'base64') {
-            kubeconfig = Buffer.from(kubeconfig, 'base64').toString('utf-8')
+         const ENCODING = {
+            BASE64: 'base64',
+            PLAINTEXT: 'plaintext'
          }
+
+         const rawKubeconfig = core.getInput('kubeconfig', {required: true})
+         const encoding =
+            core.getInput('kubeconfig-encoding')?.toLowerCase() ||
+            ENCODING.PLAINTEXT
+
+         const kubeconfig =
+            encoding === ENCODING.BASE64
+               ? Buffer.from(rawKubeconfig, ENCODING.BASE64).toString('utf-8')
+               : rawKubeconfig
+
          return kubeconfig
       }
    }

--- a/src/kubeconfigs/default.ts
+++ b/src/kubeconfigs/default.ts
@@ -45,7 +45,9 @@ export function getDefaultKubeconfig(): string {
       default: {
          core.debug('Setting context using kubeconfig')
          let kubeconfig = core.getInput('kubeconfig', {required: true})
-         const encoding = (core.getInput('kubeconfig-encoding') || 'plaintext').toLowerCase()
+         const encoding = (
+            core.getInput('kubeconfig-encoding') || 'plaintext'
+         ).toLowerCase()
          if (encoding === 'base64') {
             kubeconfig = Buffer.from(kubeconfig, 'base64').toString('utf-8')
          }


### PR DESCRIPTION
Addressed issue #146 
- Added a new input variable kubeconfigEncoding to the action.yml. This was added as an optional value for users to be able to input the encoded (base64) form of the kubeconfig input. This will will improve secure exchange of data.
- Adjusted the logic in action.ts to decode when read.
- Added appropriate tests to ensure logic works.