### PR TITLE
fix: set kubeconfig file permissions to 600 after creation

### DIFF
--- a/src/kubeconfigs/azCommands.ts
+++ b/src/kubeconfigs/azCommands.ts
@@ -36,6 +36,7 @@ export async function runAzKubeconfigCommandBlocking(
    proc.unref()
 
    await sleep(AZ_TIMEOUT_SECONDS)
+   fs.chmodSync(kubeconfigPath, 0o600)
    return fs.readFileSync(kubeconfigPath).toString()
 }
 


### PR DESCRIPTION
Kubeconfig created by az connectedk8s proxy inherits default permissions, leaving cluster credentials readable by other processes on the runner.