### PR TITLE
chore: enforce 7-day dependency freshness period + signed commit check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,28 @@ updates:
    - package-ecosystem: npm
      directory: /
      schedule:
-        interval: weekly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch
    - package-ecosystem: github-actions
      directory: .github/workflows
      schedule:
-        interval: weekly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch

--- a/.github/workflows/check-signed-commits.yml
+++ b/.github/workflows/check-signed-commits.yml
@@ -1,0 +1,12 @@
+name: Check Signed Commits
+
+on:
+   pull_request:
+
+permissions:
+   contents: read
+   pull-requests: write
+
+jobs:
+   signed:
+      uses: Azure/action-release-workflows/.github/workflows/check_signed_commits.yaml@2ff084415c5af591fd13d95ddbfc4cdb5ed2012e

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ kubectl get secret <service-account-secret-name> -n <namespace> -o yaml
      resource-group: <resource-group>
 ```
 
+## Development
+
+This repository enforces a **7-day dependency freshness ("bake") period**: newly
+published npm packages are not adopted until they have been available for at
+least 7 days, giving the ecosystem time to catch broken or malicious releases.
+
+- **Dependabot** uses a 7-day `cooldown` and opens PRs on the 1st and 15th of
+  each month, grouping minor/patch updates into a single PR. Major updates are
+  still raised individually so they get their own review.
+- **`.npmrc`** sets `min-release-age=7` (days), which applies the same rule to
+  local `npm install`. This requires npm >= 11.10.0; the version bundled with
+  Node 24 (this action's runtime) satisfies that. On older npm the setting is
+  ignored, so Dependabot's `cooldown` remains the authoritative control.
+
+**Security exception:** to adopt an urgent patch that is less than 7 days old,
+install it once with the age check disabled:
+
+```sh
+npm install <pkg> --min-release-age=0
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a


### PR DESCRIPTION
Brings k8s-set-context in line with the dependency-freshness standardization already merged in aks-set-context #258, k8s-lint #228 and k8s-bake #295. Today this repo has **no** cooldown — dependabot runs `weekly` with a single group matching `*`.